### PR TITLE
Teleport fix when DelayInTeleport is set to 0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.kondi</groupId>
     <artifactId>JustHomes</artifactId>
-    <version>1.19.0.3-SNAPSHOT</version>
+    <version>1.19.0.3</version>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.kondi</groupId>
     <artifactId>JustHomes</artifactId>
-    <version>1.19.0.2</version>
+    <version>1.19.0.3-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/me/kondi/JustHomes/Teleportation/TeleportPlayer.java
+++ b/src/main/java/me/kondi/JustHomes/Teleportation/TeleportPlayer.java
@@ -36,17 +36,17 @@ public class TeleportPlayer {
             public void run() {
                 if (tpCooldown.get(uuid) > 0) {
                     tpCooldown.put(uuid, tpCooldown.get(uuid) - 1);
-                    if (tpCooldown.get(uuid) == 0) {
-                        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(Messages.get("ActionBarNameWhileTeleporting")));
-                        p.teleport(loc);
-                        p.sendMessage(prefix + PlaceholderAPI.setPlaceholders(p, Messages.get("SuccesfullTeleportation")));
-                        tpCooldownTask.get(uuid).cancel();
-                        tpCooldown.remove(uuid);
-                        tpCooldownTask.remove(uuid);
-                    }
-                    else{
-                        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(tpCooldown.get(uuid).toString()));
-                    }
+                }
+                if (tpCooldown.get(uuid) == 0) {
+                    p.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(Messages.get("ActionBarNameWhileTeleporting")));
+                    p.teleport(loc);
+                    p.sendMessage(prefix + PlaceholderAPI.setPlaceholders(p, Messages.get("SuccesfullTeleportation")));
+                    tpCooldownTask.get(uuid).cancel();
+                    tpCooldown.remove(uuid);
+                    tpCooldownTask.remove(uuid);
+                }
+                else{
+                    p.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(tpCooldown.get(uuid).toString()));
                 }
             }
 


### PR DESCRIPTION
When DelayInTeleport is set to 0 in config.yml, the plugin will display
```
Teleporting in 0 seconds. Don't move!
```
but not actually teleport the player. The error is in me.kondi.JustHomes.Teleportation.TeleportPlayer.teleportPlayer(Player, Location, int) where the zero check of the cooldown is only performed if it was decremented before, but not if it was set to 0 right from the start.